### PR TITLE
Feat: vdom type 설정

### DIFF
--- a/global.d.ts
+++ b/global.d.ts
@@ -2,3 +2,23 @@ declare module "*.module.css" {
   const classes: { [key: string]: string };
   export default classes;
 }
+
+declare namespace JSX {
+  type Element = VNode;
+
+  interface IntrinsicElements extends IntrinsicElementMap {}
+
+  type IntrinsicElementMap = {
+    [K in keyof HTMLElementTagNameMap]: {
+      [k: string]: any;
+    };
+  };
+
+  type Tag = keyof JSX.IntrinsicElements;
+
+  type Props = Record<string, any>;
+
+  interface Component {
+    (properties?: Props, children?: (VNode | string)[]): VNode | string;
+  }
+}

--- a/global.d.ts
+++ b/global.d.ts
@@ -21,4 +21,8 @@ declare namespace JSX {
   interface Component {
     (properties?: Props, children?: (VNode | string)[]): VNode | string;
   }
+
+  interface ElementChildrenAttribute {
+    children: {};
+  }
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "@babel/preset-env": "^7.23.2",
     "@babel/preset-react": "^7.22.15",
     "@babel/preset-typescript": "^7.23.2",
-    "@types/react": "^18.2.35",
     "babel-loader": "^9.1.3",
     "css-loader": "^6.8.1",
     "html-webpack-plugin": "^5.5.3",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,12 +4,12 @@ import styles from "./main.module.css";
 import { useParams } from "./routes";
 
 interface TitleProps {
-  children: React.ReactNode;
+  children: Node;
 }
 
 interface ItemProps {
-  children: React.ReactNode;
-  onClick?: React.MouseEventHandler<HTMLLIElement>;
+  children: Node | string;
+  onClick?: (event: MouseEvent) => void;
   className?: string;
 }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,11 +4,11 @@ import styles from "./main.module.css";
 import { useParams } from "./routes";
 
 interface TitleProps {
-  children: Node;
+  children: string;
 }
 
 interface ItemProps {
-  children: Node | string;
+  children: string;
   onClick?: (event: MouseEvent) => void;
   className?: string;
 }
@@ -25,6 +25,7 @@ export function App() {
   return (
     <div>
       <Title>React 만들기</Title>
+      <Title children={<span>React 만들기</span>} />
       <ul>
         <Item onClick={() => console.log("hi")} className={styles.item}>
           item 1

--- a/src/render.ts
+++ b/src/render.ts
@@ -1,12 +1,10 @@
-type Props = Record<string, any>;
-
 export type VNode = {
-  tag: keyof HTMLElementTagNameMap | ((props: Props) => VNode);
-  props: Props;
+  tag: JSX.Tag | JSX.Component;
+  props: JSX.Props;
   children: (VNode | string)[];
 };
 
-export function createDOM(node: VNode | string): Node {
+export function createDOM(node: VNode | string) {
   if (typeof node === "string") {
     return document.createTextNode(node);
   }
@@ -39,8 +37,8 @@ export function createDOM(node: VNode | string): Node {
 }
 
 export function createElement(
-  tag: keyof HTMLElementTagNameMap | ((props: Props) => VNode),
-  props: Props,
+  tag: JSX.Tag | JSX.Component,
+  props: JSX.Props,
   ...children: (VNode | string)[]
 ) {
   const copiedProps = props ?? {};

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -1,7 +1,7 @@
 /* @jsx createElement */
 import { NotFound } from "..";
 import { VNode, createElement, render } from "../render";
-import { routes } from "./routes";
+import { Route, routes } from "./routes";
 import { isEnglish, isSamePath } from "utils";
 
 interface Params {
@@ -20,7 +20,7 @@ export const navigateTo = (url: string) => {
   router();
 };
 
-const findMatchedRouteAndParams = (routes) => {
+const findMatchedRouteAndParams = (routes: Route[]) => {
   const currentPath = location.pathname;
 
   for (const route of routes) {

--- a/src/routes/routes.ts
+++ b/src/routes/routes.ts
@@ -1,6 +1,12 @@
+import { VNode } from "src/render";
 import { App, First, Second, SecondDetail } from "..";
 
-export const routes = [
+export interface Route {
+  path: string;
+  view: () => VNode;
+}
+
+export const routes: Route[] = [
   { path: "/", view: App },
   { path: "/first", view: First },
   { path: "/second", view: Second },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1181,11 +1181,6 @@
   dependencies:
     undici-types "~5.26.4"
 
-"@types/prop-types@*":
-  version "15.7.9"
-  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.9.tgz#b6f785caa7ea1fe4414d9df42ee0ab67f23d8a6d"
-  integrity sha512-n1yyPsugYNSmHgxDFjicaI2+gCNjsBck8UX9kuofAKlc0h1bL+20oSF72KeNaW2DUlesbEVCFgyV2dPGTiY42g==
-
 "@types/qs@*":
   version "6.9.9"
   resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.9.tgz#66f7b26288f6799d279edf13da7ccd40d2fa9197"
@@ -1196,24 +1191,10 @@
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.6.tgz#7cb33992049fd7340d5b10c0098e104184dfcd2a"
   integrity sha512-+0autS93xyXizIYiyL02FCY8N+KkKPhILhcUSA276HxzreZ16kl+cmwvV2qAM/PuCCwPXzOXOWhiPcw20uSFcA==
 
-"@types/react@^18.2.35":
-  version "18.2.35"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.2.35.tgz#bacdc6d139a4d6d47e5186e1a96952c65e1f3792"
-  integrity sha512-LG3xpFZ++rTndV+/XFyX5vUP7NI9yxyk+MQvBDq+CVs8I9DLSc3Ymwb1Vmw5YDoeNeHN4PDZa3HylMKJYT9PNQ==
-  dependencies:
-    "@types/prop-types" "*"
-    "@types/scheduler" "*"
-    csstype "^3.0.2"
-
 "@types/retry@0.12.0":
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/@types/retry/-/retry-0.12.0.tgz#2b35eccfcee7d38cd72ad99232fbd58bffb3c84d"
   integrity sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==
-
-"@types/scheduler@*":
-  version "0.16.5"
-  resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.5.tgz#4751153abbf8d6199babb345a52e1eb4167d64af"
-  integrity sha512-s/FPdYRmZR8SjLWGMCuax7r3qCWQw9QKHzXVukAuuIJkXkDRwp+Pu5LMIVFi0Fxbav35WURicYr8u1QsoybnQw==
 
 "@types/send@*":
   version "0.17.3"
@@ -1827,11 +1808,6 @@ cssesc@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-3.0.0.tgz#37741919903b868565e1c09ea747445cd18983ee"
   integrity sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==
-
-csstype@^3.0.2:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.2.tgz#1d4bf9d572f11c14031f0436e1c10bc1f571f50b"
-  integrity sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==
 
 debug@2.6.9:
   version "2.6.9"


### PR DESCRIPTION
# :pray:Pull Request

## :star:제목

vdom type 설정

## :building_construction:작업 내용

- @type/react 삭제 
- 실제로 만든 타입을 vdom과 route에 적용 했습니다.

## ❗ 해결되지 않은 사항
- 함수형 컴포넌트에서 children 속성에 대한 타입에서 문제가 해결되지 않았습니다.
- `<Title>React 만들기</Title>` 안에 들어가는 내용이 children 타입으로 인식되지 않는데요..!  다음 풀리퀘때 수정해오겠습니다 🥲
```
interface TitleProps {
  children: Node;
}


function Title({ children }: TitleProps) {
  return <h1>{children}</h1>;
}

export function App() {
  return (
    <div>
      <Title>React 만들기</Title>  // children 속성이 {} 형식에 없지만 TitleProps 형식에서 필수입니다.
      <ul>
        <Item onClick={() => console.log("hi")} className={styles.item}>
          item 1
        </Item>
        <Item>item 2</Item>
        <Item>item 3</Item>
      </ul>
      <img src="https://picsum.photos/200/300" width="200" height="300" />
    </div>
  );
}

```
